### PR TITLE
fix non-dbus build

### DIFF
--- a/0008-only-enable-nsGTKRemoteServer-when-DBus-is-not-avail.patch
+++ b/0008-only-enable-nsGTKRemoteServer-when-DBus-is-not-avail.patch
@@ -5,27 +5,69 @@ Subject: [PATCH 08/18] only enable nsGTKRemoteServer when DBus is not
  available
 
 ---
- toolkit/components/remote/nsRemoteService.cpp | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ toolkit/components/remote/moz.build           |  2 +-
+ toolkit/components/remote/nsRemoteService.cpp | 16 +++++++++++-----
+ 2 files changed, 12 insertions(+), 6 deletions(-)
 
+diff --git a/toolkit/components/remote/moz.build b/toolkit/components/remote/moz.build
+index d3bab6cf..656b32c7 100644
+--- a/toolkit/components/remote/moz.build
++++ b/toolkit/components/remote/moz.build
+@@ -26,7 +26,7 @@ if CONFIG["MOZ_WIDGET_TOOLKIT"] == "gtk":
+             "nsUnixRemoteServer.h",
+             "RemoteUtils.h",
+         ]
+-    else:
++    elif CONFIG["MOZ_X11"]:
+         SOURCES += [
+             "nsGTKRemoteServer.cpp",
+             "nsXRemoteClient.cpp",
 diff --git a/toolkit/components/remote/nsRemoteService.cpp b/toolkit/components/remote/nsRemoteService.cpp
-index b2499d8191ed3..b4539f3e976c2 100644
+index b2499d81..1d1dc42e 100644
 --- a/toolkit/components/remote/nsRemoteService.cpp
 +++ b/toolkit/components/remote/nsRemoteService.cpp
-@@ -12,12 +12,12 @@
+@@ -12,12 +12,14 @@
  
  #ifdef MOZ_WIDGET_GTK
  #  include "mozilla/WidgetUtilsGtk.h"
 -#  include "nsGTKRemoteServer.h"
- #  ifdef MOZ_ENABLE_DBUS
+-#  ifdef MOZ_ENABLE_DBUS
++#  if defined(MOZ_ENABLE_DBUS)
  #    include "nsDBusRemoteServer.h"
  #    include "nsDBusRemoteClient.h"
- #  else
+-#  else
++#  elif defined(MOZ_X11)
  #    include "nsXRemoteClient.h"
 +#    include "nsGTKRemoteServer.h"
++#  else
++#    include "nsRemoteClient.h"
  #  endif
  #elif defined(XP_WIN)
  #  include "nsWinRemoteServer.h"
+@@ -102,8 +104,10 @@ RemoteResult nsRemoteService::StartClient(const char* aDesktopStartupID) {
+ #ifdef MOZ_WIDGET_GTK
+ #  if defined(MOZ_ENABLE_DBUS)
+   client = MakeUnique<nsDBusRemoteClient>();
+-#  else
++#  elif defined(MOZ_X11)
+   client = MakeUnique<nsXRemoteClient>();
++#  else
++  return REMOTE_NOT_FOUND;
+ #  endif
+ #elif defined(XP_WIN)
+   client = MakeUnique<nsWinRemoteClient>();
+@@ -146,8 +150,10 @@ void nsRemoteService::StartupServer() {
+ #ifdef MOZ_WIDGET_GTK
+ #  if defined(MOZ_ENABLE_DBUS)
+   mRemoteServer = MakeUnique<nsDBusRemoteServer>();
+-#  else
++#  elif defined(MOZ_X11)
+   mRemoteServer = MakeUnique<nsGTKRemoteServer>();
++#  else
++  return;
+ #  endif
+ #elif defined(XP_WIN)
+   mRemoteServer = MakeUnique<nsWinRemoteServer>();
 -- 
 2.35.1
 


### PR DESCRIPTION
Hi, this adds some stubs in `0008-only-enable-nsGTKRemoteServer-when-DBus-is-not-avail.patch` to allow building for wayland without dbus while not impacting a normal x11 build. Builds fine for me.